### PR TITLE
Authorize zero as value for a sample

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -613,9 +613,6 @@ function apiAddSample(apiData, hdl) {
       if (typeof(sample.value) !== 'number') {
         return hdl('Invalid data - sample.value is not a number');
       }
-      if (sample.value === 0) {
-        return hdl('Invalid data - sample.value is zero');
-      }
       //
       // Serie analysis for benchmark
       //


### PR DESCRIPTION
Otherwise this causes bugs in some Dana pages.
Series with zero value were uploaded from bot to
Dana, but json file only contained series info,
but no 'sample' subelement.