### PR TITLE
Re-order queue so that all tasks progress at about same speed

### DIFF
--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -472,7 +472,6 @@ function internalCheckTasks() {
           console.log('nodeCiBot', 'ERROR mode is invalid', t.mode);
         if (globalBot.debug) console.log('patches computed', patches.length)
 
-        //patches.reverse();
         for (var jj in patches) {
           if (globalBot.debug) console.log('getBuildId', jj)
           var bId = gitForBot.getBuildId(patches[jj]);

--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -391,6 +391,7 @@ function internalCheckTasks() {
   var t;
   var ii;
   var k = Object.keys(globalBot.tasks);
+  var tasksInfos = {};
   for (ii in k) {
     tName = k[ii];
     t = globalBot.tasks[tName];
@@ -471,7 +472,7 @@ function internalCheckTasks() {
           console.log('nodeCiBot', 'ERROR mode is invalid', t.mode);
         if (globalBot.debug) console.log('patches computed', patches.length)
 
-        patches.reverse();
+        //patches.reverse();
         for (var jj in patches) {
           if (globalBot.debug) console.log('getBuildId', jj)
           var bId = gitForBot.getBuildId(patches[jj]);
@@ -488,24 +489,55 @@ function internalCheckTasks() {
             }
           }
 
-          globalBot.Q[globalBot.QId] = {
-            id: globalBot.QId,
-            task: tName,
+          if (tasksInfos[tName] === undefined) {
+            let infos= [];
+            tasksInfos[tName] = {
+              infos: infos
+            }
+          }
+          tasksInfos[tName].infos.push({
+            tName: tName,
             buildId: bId,
-            repository: t.repository,
             patch: patches[jj],
-            infos: pInfo
-          };
-          globalBot.QId++;
+            pInfo: pInfo
+          });
 
         }
 
         tasksCurrentTot[tName].currentTot = remoteTot;
         www.updateQueue();
       }
-      if (globalBot.debug) console.log('checking done')
     }
   }
+
+  let keepGoing = true;
+  while(keepGoing) {
+    if (Object.keys(tasksInfos).length === 0) {
+      break;
+    }
+    keepGoing = false;
+    // Consume and push to queue 1 build per task until none is left
+    for (var tinfo in tasksInfos) {
+      if (tasksInfos[tinfo].infos.length == 0) {
+        continue;
+      }
+      keepGoing = true;
+      var info = tasksInfos[tinfo].infos.pop();
+      globalBot.Q[globalBot.QId] = {
+        id: globalBot.QId,
+        task: info.tName,
+        buildId: info.buildId,
+        repository: globalBot.tasks[info.tName].repository,
+        patch: info.patch,
+        infos: info.pInfo
+      };
+      globalBot.QId++;
+      www.updateQueue();
+    }
+  }
+
+  if (globalBot.debug) console.log('checking done')
+
 }
 
 function internalQNotifyEnd() {

--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -489,7 +489,7 @@ function internalCheckTasks() {
           }
 
           if (tasksInfos[tName] === undefined) {
-            let infos= [];
+            let infos = [];
             tasksInfos[tName] = {
               infos: infos
             }
@@ -510,14 +510,14 @@ function internalCheckTasks() {
   }
 
   let keepGoing = true;
-  while(keepGoing) {
+  while (keepGoing) {
     if (Object.keys(tasksInfos).length === 0) {
       break;
     }
     keepGoing = false;
     // Consume and push to queue 1 build per task until none is left
     for (var tinfo in tasksInfos) {
-      if (tasksInfos[tinfo].infos.length == 0) {
+      if (tasksInfos[tinfo].infos.length === 0) {
         continue;
       }
       keepGoing = true;


### PR DESCRIPTION
Currently the queue takes all builds from one task before beginning
with the next. So if one wants to play many builds on the same repo
for multiple tasks, it can take long before results can be compared.
With this CL, build A will be executed for those tasks before moving
to build B, thus solving this issue.

Fixes #25 