### PR TITLE
Issue 13 change q management

### DIFF
--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -460,7 +460,6 @@ function internalCheckTasks() {
         if (t.mode === "patch") {
           let iterCommit = repoTot;
           while (iterCommit !== tasksCurrentTot[tName].currentTot  /*t.currentTot*/ /*t.base*/ && patches.length < globalBot.limitPatches) {
-            console.log('JMH', iterCommit)
             patches.push(iterCommit);
             if (globalBot.debug) console.log('repoResetHardPrevious')
             iterCommit = gitForBot.repoResetHardPrevious();
@@ -1008,7 +1007,6 @@ function userRunEnd(msg) {
   fs.writeFileSync(f, JSON.stringify(globalBot.currentRun));
 
   g.tasks[g.running.task].base = b.infos.hash;
-  console.log('JMH', g.tasks[g.running.task], b.infos.hash);
   internalSaveContext();
   www.updateTasks();
 

--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -464,7 +464,6 @@ function internalCheckTasks() {
             if (globalBot.debug) console.log('repoResetHardPrevious')
             iterCommit = gitForBot.repoResetHardPrevious();
           }
-          //patches = [patches.pop()];
         } else
         if (t.mode === "patchSet") {
           if (repoTot !== t.base) {

--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -464,6 +464,7 @@ function internalCheckTasks() {
             if (globalBot.debug) console.log('repoResetHardPrevious')
             iterCommit = gitForBot.repoResetHardPrevious();
           }
+          //patches = [patches.pop()];
         } else
         if (t.mode === "patchSet") {
           if (repoTot !== t.base) {

--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -448,23 +448,18 @@ function internalCheckTasks() {
         tasksCurrentTot[tName] = { currentTot: t.base };
       }
 
-      // if (t.currentTot === undefined) {
-      //   t.currentTot = t.base;
-      // }
-
-      if (remoteTot !== tasksCurrentTot[tName].currentTot  /*t.currentTot*/ /*t.base*/) {
+      if (remoteTot !== tasksCurrentTot[tName].currentTot) {
         if (globalBot.debug) console.log('repoResetHard')
         gitForBot.repoResetHard(remoteTot);
         if (globalBot.debug) console.log('getRepoToT')
         var repoTot = gitForBot.getRepoToT();        
         if (t.mode === "patch") {
           let iterCommit = repoTot;
-          while (iterCommit !== tasksCurrentTot[tName].currentTot  /*t.currentTot*/ /*t.base*/ && patches.length < globalBot.limitPatches) {
+          while (iterCommit !== tasksCurrentTot[tName].currentTot && patches.length < globalBot.limitPatches) {
             patches.push(iterCommit);
             if (globalBot.debug) console.log('repoResetHardPrevious')
             iterCommit = gitForBot.repoResetHardPrevious();
           }
-          //patches = [patches.pop()];
         } else
         if (t.mode === "patchSet") {
           if (repoTot !== t.base) {
@@ -504,9 +499,6 @@ function internalCheckTasks() {
         }
 
         tasksCurrentTot[tName].currentTot = remoteTot;
-
-        // t.base = remoteTot;
-        //internalSaveContext();
         www.updateQueue();
       }
       if (globalBot.debug) console.log('checking done')
@@ -588,7 +580,6 @@ One task:
     "fixedTime" // indicate the time (in hour:minutes) to launch the run
   },
   "base": "c24c7a5d1170d09e75db822daa1
-  "currentTot": "c24c7a5d1170d09e75db822daa1"
 }
 
 */

--- a/dana-bot/src/www.js
+++ b/dana-bot/src/www.js
@@ -982,3 +982,4 @@ module.exports.startingBuild = startingBuild;
 module.exports.updatingBuild = updatingBuild;
 module.exports.stoppingBuild = stoppingBuild;
 module.exports.updateQueue = updateQueue;
+module.exports.updateTasks = updateTasks;


### PR DESCRIPTION
This change modifies the meaning of the task base.
Here, task base is used to save the last know finished build.
Thus, once it's serialized in config/tasks.json, the bot can continue where it left off even after being killed.

It addresses issue #13 except that initially, it was considered to only allow one build per task.
Working on this change has proven me it's not necessary, and that only the change in how 'base' is handled is enough to achieve the initial goal of being able to restart the bot without missing some builds.

Now if we really want it to be one build per task, it may be possible, but it would require more changes, I just wanted to suggest this as is, for discussion, since it seems to solve the initial problem.
