### PR TITLE
Reset a flag for the export status of finished build

### DIFF
--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -785,7 +785,8 @@ function userRunStart(msg) {
     maxSamples: 0,
     sequences: {},
     failingSeries: [],
-    allSeries: []
+    allSeries: [],
+    metadata: {}
   };
 
   www.startingBuild();
@@ -1024,8 +1025,6 @@ function userRunEnd(msg) {
   var f = globalBot.buildPath + '/' + g.running.task;
   if (!fs.existsSync(f))
     fs.mkdirSync(f);
-
-  globalBot.currentRun.exportedTo = [];
 
   var f = globalBot.buildPath + '/' + g.running.task + '/' + b.buildId + '.json';
   fs.writeFileSync(f, JSON.stringify(globalBot.currentRun.allSeries));

--- a/dana-bot/src/bot.js
+++ b/dana-bot/src/bot.js
@@ -1025,6 +1025,8 @@ function userRunEnd(msg) {
   if (!fs.existsSync(f))
     fs.mkdirSync(f);
 
+  globalBot.currentRun.exportedTo = [];
+
   var f = globalBot.buildPath + '/' + g.running.task + '/' + b.buildId + '.json';
   fs.writeFileSync(f, JSON.stringify(globalBot.currentRun.allSeries));
   var f = globalBot.buildPath + '/' + g.running.task + '/' + b.buildId + '.full.json';


### PR DESCRIPTION
This flag can be used by projects to determine whether
this build has just finished or not. It is supposed to
hold the list the build has already been exported to.