### PR TITLE
Rename Dylib to LLVM-CPU in dashboard UI

### DIFF
--- a/www/views/projects/IREE/sidebar.ejs
+++ b/www/views/projects/IREE/sidebar.ejs
@@ -89,8 +89,8 @@
             </a>
             <ul class="nav child_menu">
               <li>
-                <a href="/IREE/statusDylibDriverSeries">
-                  IREE Dylib
+                <a href="/IREE/statusLLVMCPUDriverSeries">
+                  IREE LLVM CPU
                 </a>
               </li>
               <li>

--- a/www/views/projects/IREE/statusLLVMCPUDriverSeries.ejs
+++ b/www/views/projects/IREE/statusLLVMCPUDriverSeries.ejs
@@ -68,7 +68,7 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'IREE-Dylib'
+        serieFilter:'IREE-LLVM-CPU'
       });
     </script>
 


### PR DESCRIPTION
The follow-up of https://github.com/iree-org/iree/pull/9942