### PR TITLE
Fix range unit conversion for legacy API

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -556,6 +556,7 @@ function apiAddSerie(apiData, hdl, apiVersion) {
       if (!range.toString().endsWith("%") && serieUnit == "ns") {
         range = Math.floor(moduleUtils.unitConversion(range, "ms", "ns"));
       }
+      serie.analyse.benchmark.range = range;
     }
   }
   if (analyse.test) {


### PR DESCRIPTION
For legacy API without series unit, the previous change forgot to populate the auto-converted analysis range.