### PR TITLE
Better organize the benchmarks and compilation statistics pages

### DIFF
--- a/www/views/common/pageSeries.ejs
+++ b/www/views/common/pageSeries.ejs
@@ -206,10 +206,10 @@
       var defLength = 15;
       var socket = io();
 
-      function start(tprojectId, tSerieFilter) {
+      function start(tprojectId, tSerieFilter, title) {
         projectId = tprojectId;
         serieFilter = tSerieFilter;
-        $('#page_title_description').html((serieFilter ?? '') + ' Benchmark Status for ' + projectId + ' <small>Based on latest results</small>');
+        $('#page_title_description').html((title ?? '') + ' Benchmark Status for ' + projectId + ' <small>Based on latest results</small>');
 
         socket.on('receiveFileInfo', function(req) {
           if (debug)
@@ -278,7 +278,7 @@
         for (var ii = 0; ii < k.length; ii++) {
           var s = series[k[ii]];
           if (serieFilter)
-            if (s.serieName.indexOf(serieFilter) === -1)
+            if (s.serieName.search(serieFilter) === -1)
               continue;
 
           numSeries++;
@@ -816,7 +816,7 @@
           }
 
           if (serieFilter)
-            if (s.serieName.indexOf(serieFilter) === -1)
+            if (s.serieName.search(serieFilter) === -1)
               continue;
 
           if (mode === 'undefined') {
@@ -1144,7 +1144,7 @@
         return '';
       }
       $(document).ready(function() {
-        start(userPage.projectId, userPage.serieFilter);
+        start(userPage.projectId, userPage.serieFilter, userPage.title);
         $('#myModal').on('shown.bs.modal', function(e) {
           uiShowSerie('statusSeries', projectId, serieId);
           $('#commentsArea').linkify({

--- a/www/views/projects/IREE/sidebar.ejs
+++ b/www/views/projects/IREE/sidebar.ejs
@@ -66,11 +66,6 @@
                 </a>
               </li>
               <li>
-                <a href="/IREE/statusRISCVCPUSeries">
-                  RISC-V CPU
-                </a>
-              </li>
-              <li>
                 <a href="/IREE/statusMaliGPUSeries">
                   Mali GPU
                 </a>
@@ -106,6 +101,29 @@
               <li>
                 <a href="/IREE/statusVMVXDriverSeries">
                   IREE VMVX (Experimental)
+                </a>
+              </li>
+            </ul>
+          </li>
+          <li>
+            <a>
+              <i class="fa fa-rocket"></i>
+              Compilation Statistics<span class="fa fa-chevron-down"></span>
+            </a>
+            <ul class="nav child_menu">
+              <li>
+                <a href="/IREE/statusCompilationTimeSeries">
+                  Compilation Time
+                </a>
+              </li>
+              <li>
+                <a href="/IREE/statusTotalDispatchSizeSeries">
+                  Total Dispatch Size
+                </a>
+              </li>
+              <li>
+                <a href="/IREE/statusTotalArtifactSizeSeries">
+                  Total Artifact Size
                 </a>
               </li>
             </ul>

--- a/www/views/projects/IREE/statusAdrenoGPUSeries.ejs
+++ b/www/views/projects/IREE/statusAdrenoGPUSeries.ejs
@@ -68,7 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'GPU-Adreno'
+        serieFilter: '@.+GPU-Adreno',
+        title: 'Adreno GPU (Experimental)'
       });
     </script>
 

--- a/www/views/projects/IREE/statusCUDAGPUSeries.ejs
+++ b/www/views/projects/IREE/statusCUDAGPUSeries.ejs
@@ -68,7 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'CUDA'
+        serieFilter: 'IREE-CUDA.+@',
+        title: 'CUDA GPU'
       });
     </script>
 

--- a/www/views/projects/IREE/statusCompilationTimeSeries.ejs
+++ b/www/views/projects/IREE/statusCompilationTimeSeries.ejs
@@ -1,6 +1,6 @@
 <!--
 /*
- * Copyright 2017 Google Inc. All rights reserved.
+ * Copyright 2023 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,8 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter: '@.+CPU-ARM',
-        title: 'ARM CPU'
+        serieFilter: 'compilation:module:compilation-time',
+        title: 'Compilation Time'
       });
     </script>
 

--- a/www/views/projects/IREE/statusLLVMCPUDriverSeries.ejs
+++ b/www/views/projects/IREE/statusLLVMCPUDriverSeries.ejs
@@ -68,7 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'IREE-LLVM-CPU'
+        serieFilter: 'IREE-LLVM-CPU.+@',
+        title: 'IREE LLVM CPU'
       });
     </script>
 

--- a/www/views/projects/IREE/statusMaliGPUSeries.ejs
+++ b/www/views/projects/IREE/statusMaliGPUSeries.ejs
@@ -68,7 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'GPU-Mali'
+        serieFilter: '@.+GPU-Mali',
+        title: 'Mali GPU'
       });
     </script>
 

--- a/www/views/projects/IREE/statusOverall.ejs
+++ b/www/views/projects/IREE/statusOverall.ejs
@@ -67,7 +67,8 @@
 
 		<script>
 			setOverallPage({
-				projectId: 'IREE'
+				projectId: 'IREE',
+				title: 'Overall'
 			});
 		</script>
 

--- a/www/views/projects/IREE/statusSeries.ejs
+++ b/www/views/projects/IREE/statusSeries.ejs
@@ -67,7 +67,8 @@
 
 		<script>
 			setSeriesPage({
-				projectId: 'IREE'
+				projectId: 'IREE',
+				title: 'All'
 			});
 		</script>
 

--- a/www/views/projects/IREE/statusTotalArtifactSizeSeries.ejs
+++ b/www/views/projects/IREE/statusTotalArtifactSizeSeries.ejs
@@ -1,6 +1,6 @@
 <!--
 /*
- * Copyright 2017 Google Inc. All rights reserved.
+ * Copyright 2023 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,7 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'CPU-RV'
+        serieFilter: 'compilation:module:total-artifact-size',
+        title: 'Total Artifact Size'
       });
     </script>
 

--- a/www/views/projects/IREE/statusTotalDispatchSizeSeries.ejs
+++ b/www/views/projects/IREE/statusTotalDispatchSizeSeries.ejs
@@ -1,6 +1,6 @@
 <!--
 /*
- * Copyright 2017 Google Inc. All rights reserved.
+ * Copyright 2023 Google Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,8 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter: '@.+CPU-ARM',
-        title: 'ARM CPU'
+        serieFilter: 'compilation:module:component-size:total-dispatch-size',
+        title: 'Total Dispatch Size'
       });
     </script>
 

--- a/www/views/projects/IREE/statusVMVXDriverSeries.ejs
+++ b/www/views/projects/IREE/statusVMVXDriverSeries.ejs
@@ -68,7 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'IREE-VMVX'
+        serieFilter: 'IREE-VMVX.+@',
+        title: 'IREE VMVX (Experimental)'
       });
     </script>
 

--- a/www/views/projects/IREE/statusVulkanDriverSeries.ejs
+++ b/www/views/projects/IREE/statusVulkanDriverSeries.ejs
@@ -68,7 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'IREE-Vulkan'
+        serieFilter: 'IREE-Vulkan.+@',
+        title: 'IREE Vulkan'
       });
     </script>
 

--- a/www/views/projects/IREE/statusX86CPUSeries.ejs
+++ b/www/views/projects/IREE/statusX86CPUSeries.ejs
@@ -68,7 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter:'CPU-x86_64'
+        serieFilter: '@.+CPU-x86_64',
+        title: 'X86_64 CPU'
       });
     </script>
 


### PR DESCRIPTION
- Support regex for filtering benchmarks of a page
  - Required for differentiating the latency benchmarks and compilation statistics benchmarks
- Support the page title field, which shows a friendly page title
- Reorganize the IREE benchmark pages, compilation statistics are now in their own pages.