### PR TITLE
Fix the display unit when special rules don't match

### DIFF
--- a/www/public/js/uilibOne.js
+++ b/www/public/js/uilibOne.js
@@ -70,6 +70,8 @@ function uiShowSerie(tpageType, tprojectId, tserieId) {
         displayUnit = 'ms'
       else if  (serie.serieUnit === 'bytes')
         displayUnit = 'kbytes'
+      else
+        displayUnit = serie.serieUnit
     }
 
     if (pageType === 'showOneSerie')


### PR DESCRIPTION
If the series unit doesn't match any conversion rules, fallback to show the original series unit.

Fix the NaN shown on the compilation pages.