### PR TITLE
Upload filters for new benchmark name format

### DIFF
--- a/www/views/projects/IREE/default-cuda-gpu-series.ejs
+++ b/www/views/projects/IREE/default-cuda-gpu-series.ejs
@@ -68,8 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter: 'default-flags.+IREE-CUDA.+@',
-        title: 'CUDA GPU'
+        serieFilter: 'cuda.+default-flags.+@',
+        title: 'CUDA GPU Default Flags'
       });
     </script>
 

--- a/www/views/projects/IREE/default-llvm-cpu-driver-series.ejs
+++ b/www/views/projects/IREE/default-llvm-cpu-driver-series.ejs
@@ -68,8 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter: 'default-flags.+IREE-LLVM-CPU.+@',
-        title: 'IREE LLVM CPU'
+        serieFilter: 'default-flags.+(IREE-LLVM-CPU|local_sync|local_task).+@',
+        title: 'IREE LLVM CPU Default Flags'
       });
     </script>
 

--- a/www/views/projects/IREE/default-x86-cpu-series.ejs
+++ b/www/views/projects/IREE/default-x86-cpu-series.ejs
@@ -68,8 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter: 'default-flags.+@.+CPU-x86_64',
-        title: 'X86_64 CPU'
+        serieFilter: 'x86_64.+default-flags.+@',
+        title: 'X86_64 CPU Default Flags'
       });
     </script>
 

--- a/www/views/projects/IREE/experimental-cuda-gpu-series.ejs
+++ b/www/views/projects/IREE/experimental-cuda-gpu-series.ejs
@@ -68,8 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter: 'experimental-flags.+IREE-CUDA.+@',
-        title: 'CUDA GPU'
+        serieFilter: 'cuda.+experimental-flags.+@',
+        title: 'CUDA GPU Experimental Flags'
       });
     </script>
 

--- a/www/views/projects/IREE/experimental-llvm-cpu-driver-series.ejs
+++ b/www/views/projects/IREE/experimental-llvm-cpu-driver-series.ejs
@@ -68,8 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter: 'experimental-flags.+IREE-LLVM-CPU.+@',
-        title: 'IREE LLVM CPU'
+        serieFilter: 'experimental-flags.+(IREE-LLVM-CPU|local_sync|local_task).+@',
+        title: 'IREE LLVM CPU Experimental Flags'
       });
     </script>
 

--- a/www/views/projects/IREE/experimental-x86-cpu-series.ejs
+++ b/www/views/projects/IREE/experimental-x86-cpu-series.ejs
@@ -68,8 +68,8 @@
     <script>
       setSeriesPage({
         projectId: 'IREE',
-        serieFilter: 'experimental-flags.+@.+CPU-x86_64',
-        title: 'X86_64 CPU'
+        serieFilter: 'x86_64.+experimental-flags.+@',
+        title: 'X86_64 CPU Experimental Flags'
       });
     </script>
 


### PR DESCRIPTION
Update filters of x86_64, CUDA, and compilation statistics for the new name format introduced by https://github.com/openxla/iree/pull/12649