### PR TITLE
Add RISC-V benchmark pages

### DIFF
--- a/www/views/common/pageSeries.ejs
+++ b/www/views/common/pageSeries.ejs
@@ -83,6 +83,7 @@
         <div class="x_title">
           <h2>Benchmarks
             </h2>
+	  <div id="extraInfo" class="col-md-12"></div>
           <ul class="nav navbar-right panel_toolbox">
             <!-- <li class="dropdown"> <a href="#download"><i class="fa fa-download"></i></a> </li> -->
             <li>
@@ -206,10 +207,11 @@
       var defLength = 15;
       var socket = io();
 
-      function start(tprojectId, tSerieFilter, title) {
+      function start(tprojectId, tSerieFilter, title, extraInfo) {
         projectId = tprojectId;
         serieFilter = tSerieFilter;
         $('#page_title_description').html((title ?? '') + ' Benchmark Status for ' + projectId + ' <small>Based on latest results</small>');
+        $('#extraInfo').html((extraInfo ?? ''));
 
         socket.on('receiveFileInfo', function(req) {
           if (debug)
@@ -1144,7 +1146,7 @@
         return '';
       }
       $(document).ready(function() {
-        start(userPage.projectId, userPage.serieFilter, userPage.title);
+        start(userPage.projectId, userPage.serieFilter, userPage.title, userPage.extraInfo);
         $('#myModal').on('shown.bs.modal', function(e) {
           uiShowSerie('statusSeries', projectId, serieId);
           $('#commentsArea').linkify({

--- a/www/views/projects/IREE/default-riscv-cpu-scaled-series.ejs
+++ b/www/views/projects/IREE/default-riscv-cpu-scaled-series.ejs
@@ -1,0 +1,78 @@
+<!--
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<!DOCTYPE html>
+<html lang="en">
+
+<%- include('../../common/head') %>
+
+  <body class="nav-md">
+    <div class="container body">
+      <div class="main_container">
+        <%- include('sidebar') %>
+
+          <!-- top navigation -->
+          <div class="top_nav navbar-fixed-top">
+            <div class="nav_menu">
+              <nav class="" role="navigation">
+                <div class="nav toggle">
+                  <a id="menu_toggle">
+                  <i class="fa fa-bars"></i>
+                </a>
+                </div>
+                <ul class="nav navbar-nav">
+                  <h3 id='page-title' class="navbar-text">
+                    <span id='page_title_description'></span></h3>
+                </ul>
+                <ul class="nav navbar-nav navbar-right" style="width: auto">
+                  <% if (user===undefined) { %>
+                    <li>
+                      <a href="/login">
+                        Admin Login
+                      </a>
+                    </li>
+                  <% } else { %>
+                    <li>
+                      <a href="/logout">
+                        <% if (user!==undefined) { %>
+                          Logout <%=user.username%>
+                        <% } %>
+                      </a>
+                    </li>
+                  <% } %>
+                </ul>
+              </nav>
+            </div>
+          </div>
+          <!-- /top navigation -->
+
+          <%- include('../../common/pageSeries') %>
+
+      </div>
+    </div>
+
+    <script>
+      setSeriesPage({
+        projectId: 'IREE',
+        serieFilter: 'riscv.+default-flags.+@.+\\[theoretically-scaled,cpu\\]',
+        title: 'RISC-V CPU Default Flags (Theoretically Scaled)',
+	extraInfo: '<b>Series in this page are scaled to reflect the theoretical performance. Details are shown in each series page.<br>For more information, please ask on <a href="https://github.com/openxla/iree#communication-channels">IREE Communication Channels</a>.</b>',
+      });
+    </script>
+
+  </body>
+</html>

--- a/www/views/projects/IREE/default-riscv-cpu-series.ejs
+++ b/www/views/projects/IREE/default-riscv-cpu-series.ejs
@@ -1,0 +1,77 @@
+<!--
+/*
+ * Copyright 2017 Google Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+<!DOCTYPE html>
+<html lang="en">
+
+<%- include('../../common/head') %>
+
+  <body class="nav-md">
+    <div class="container body">
+      <div class="main_container">
+        <%- include('sidebar') %>
+
+          <!-- top navigation -->
+          <div class="top_nav navbar-fixed-top">
+            <div class="nav_menu">
+              <nav class="" role="navigation">
+                <div class="nav toggle">
+                  <a id="menu_toggle">
+                  <i class="fa fa-bars"></i>
+                </a>
+                </div>
+                <ul class="nav navbar-nav">
+                  <h3 id='page-title' class="navbar-text">
+                    <span id='page_title_description'></span></h3>
+                </ul>
+                <ul class="nav navbar-nav navbar-right" style="width: auto">
+                  <% if (user===undefined) { %>
+                    <li>
+                      <a href="/login">
+                        Admin Login
+                      </a>
+                    </li>
+                  <% } else { %>
+                    <li>
+                      <a href="/logout">
+                        <% if (user!==undefined) { %>
+                          Logout <%=user.username%>
+                        <% } %>
+                      </a>
+                    </li>
+                  <% } %>
+                </ul>
+              </nav>
+            </div>
+          </div>
+          <!-- /top navigation -->
+
+          <%- include('../../common/pageSeries') %>
+
+      </div>
+    </div>
+
+    <script>
+      setSeriesPage({
+        projectId: 'IREE',
+        serieFilter: 'riscv.+default-flags.+@.+\\[cpu\\]',
+        title: 'RISC-V CPU Default Flags'
+      });
+    </script>
+
+  </body>
+</html>

--- a/www/views/projects/IREE/sidebar.ejs
+++ b/www/views/projects/IREE/sidebar.ejs
@@ -91,6 +91,16 @@
                 </a>
               </li>
               <li>
+                <a href="/IREE/default-riscv-cpu-series">
+                  RISC-V CPU <br> (default-flags)
+                </a>
+              </li>
+              <li>
+                <a href="/IREE/default-riscv-cpu-scaled-series">
+                  RISC-V CPU <br> (default-flags,theoretically-scaled)
+                </a>
+              </li>
+              <li>
                 <a href="/IREE/default-adreno-gpu-series">
                   Adreno GPU <br> (default-flags)
                 </a>


### PR DESCRIPTION
Add RISC-V benchmark pages.

An `extraInfo` div block is added to series page to explain RISC-V benchmarks